### PR TITLE
Add thinking pattern analysis API endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from flask_cors import CORS
 from app.routes.sentimental_routes import sentimental_blueprint
 from app.routes.screenstats_routes import screenstats_blueprint
 from app.routes.voice_recognition_routes import voice_bp
+from app.routes.thinking_route import thinking_blueprint
 
 app = Flask(__name__)
 app.config['UPLOAD_FOLDER'] = 'uploads'
@@ -12,6 +13,7 @@ app.config['UPLOAD_FOLDER'] = 'uploads'
 app.register_blueprint(sentimental_blueprint, url_prefix="/sentiment")
 app.register_blueprint(screenstats_blueprint, url_prefix="/screenstats")
 app.register_blueprint(voice_bp, url_prefix="/api/voice")
+app.register_blueprint(thinking_blueprint, url_prefix="/thinking")
 
 # Enable CORS
 CORS(app)

--- a/app/routes/thinking_route.py
+++ b/app/routes/thinking_route.py
@@ -1,0 +1,12 @@
+from flask import Blueprint, request, jsonify
+from app.services.thinking_analysis import analyze_thinking_pattern
+
+thinking_blueprint = Blueprint('thinking', __name__)
+
+@thinking_blueprint.route('/analyze', methods=['POST'])
+def analyze():
+    data = request.json
+    input_data = data.get('input_data', [])
+    prediction = analyze_thinking_pattern(input_data)
+    return jsonify({"prediction": prediction})
+

--- a/app/services/thinking_analysis.py
+++ b/app/services/thinking_analysis.py
@@ -1,0 +1,18 @@
+import pickle
+import os
+
+# Define the path to the model file
+model_path = os.path.join(os.path.dirname(__file__), 'thinkingpattern.pkl')
+
+# Load the model
+def load_model(path):
+    with open(path, 'rb') as file:
+        model = pickle.load(file)
+    return model
+
+# Use the model for prediction
+def analyze_thinking_pattern(input_data):
+    model = load_model(model_path)
+    prediction = model.predict([input_data])  # Assuming input_data is a single feature vector
+    return prediction
+


### PR DESCRIPTION
Introduces a new '/thinking/analyze' POST endpoint and supporting service for analyzing thinking patterns using a pre-trained model. Updates main.py to register the new blueprint.